### PR TITLE
Changing JSON Processor for sorting purposes

### DIFF
--- a/examples/kafka/build.gradle
+++ b/examples/kafka/build.gradle
@@ -75,3 +75,7 @@ jar {
      )
   }
 }
+
+dependencies {
+  implementation 'com.google.code.gson:gson:2.10.1'
+}


### PR DESCRIPTION
In this Pull Request I've update the JSON processor in order to use the Google one, the GSON library. It keeps sorting the fields as shared by Adabas Event Replicator. The structure is sorted and slightly different as the JSON produced has \n between fields.